### PR TITLE
Added hostname to the configurations

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -7,6 +7,7 @@ services:
     image: rabbitmq:3-management-alpine
     networks:
       - rmq-net
+    hostname: rmq
     ports:
       - "5672:5672"
       - "15672:15672"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,7 @@ services:
     image: rabbitmq:3-management-alpine
     networks:
       - rmq-net
-    secrets:
-      - rabbitmq_default_pass
+    hostname: rmq
     ports:
       - "127.0.0.1:5672:5672"
       - "127.0.0.1:15672:15672"


### PR DESCRIPTION
Установлено, что существовала проблема, при перезапуске контейнера rabbitmq, сервис как бы создавал новую БД.
Это в том числе повлияло на возникновение вот этого issue https://github.com/terratensor/tg-svodd-bot/issues/15
Было выяснено, что новая БД действительно создавалась с новыми данными, а старая БД оставалась в хранилище volume
Подробнее здесь: 
https://stackoverflow.com/questions/41330514/docker-rabbitmq-persistency
https://github.com/docker-library/rabbitmq/issues/106#issuecomment-241882358

Для того, чтобы сервис после рестарта подцеплял старую БД, необходимо в настройках docker-compose указать hostname, т.к. rabbitmq по умолчанию создает базу данных с именем hostname от которого он запущен.

Это настройка, частично решает проблему https://github.com/terratensor/tg-svodd-bot/issues/15 , она сводит возникновение этой проблемы к минимуму, но вероятность возникновения этой ошибки у сервиса телеграм бота все ещё остается, в этом случае необходимо перезапустить сервис tg-svodd-bot после создания очереди q1